### PR TITLE
Fix typo in ShowYourStripes link description

### DIFF
--- a/html_layout.py
+++ b/html_layout.py
@@ -1047,7 +1047,7 @@ def create_appLayout(
                             "from 1850 to 2018. "
                             "This striking design was made by Ed Hawkins from the University of Reading. "),
                             html.P(["More on ",
-                                    html.A("ShowYourStipes.info",
+                                    html.A("ShowYourStripes.info",
                                            href='https://showyourstripes.info',
                                            target='_blank')]),
                             html.P(["Additional credits for the app can be found on the ",

--- a/old/app.py
+++ b/old/app.py
@@ -886,7 +886,7 @@ app.layout = html.Div(
                         from 1850 to 2018.
                         This striking design has been made by Ed Hawkins from the University of Reading.
 
-                        More on [ShowYourStipes.info](https://showyourstripes.info)
+                        More on [ShowYourStripes.info](https://showyourstripes.info)
                         ''')
                     ],
                     className="pretty_container four columns",


### PR DESCRIPTION
Hi! I noticed a typo in the link to showyourstripes.info, its description says stipes not stripes.