### PR TITLE
add hardware used by UofA HPC

### DIFF
--- a/data/latest/TDP_cpu.csv
+++ b/data/latest/TDP_cpu.csv
@@ -6,6 +6,7 @@ AMD 7552,200,48,4.2,,,,https://www.amd.com/system/files/documents/AMD-EPYC-7002-
 AMD EPYC 7251,120,8,15.0,,,,https://www.amd.com/en/products/cpu/amd-epyc-7251
 AMD EPYC 7343,190,16,11.9,,,,https://www.amd.com/en/products/cpu/amd-epyc-7343
 AMD EPYC 7513,200,32,6.3,,,,https://www.amd.com/en/products/cpu/amd-epyc-7513
+AMD EPYC 7642,225,48,4.7,,,,https://www.techpowerup.com/cpu-specs/epyc-7642.c2247
 AMD EPYC 7763,280,64,4.4,,,,https://www.amd.com/en/products/cpu/amd-epyc-7763 
 AMD EPYC 7773X,280,64,4.4,,,,https://www.amd.com/en/products/cpu/amd-epyc-7773x 
 AMD EPYC 7H12,280,64,4.4,,,,https://www.amd.com/en/product/9131 
@@ -64,12 +65,14 @@ Ryzen Threadripper 2990WX,250,32,7.8,,,,https://www.techpowerup.com/cpu-specs/
 Ryzen Threadripper 3990X,280,64,4.4,,,,https://www.techpowerup.com/cpu-specs/
 Xeon E5-2660 v3,105,10,10.5,,,,https://ark.intel.com/content/www/us/en/ark/products/81706/intel-xeon-processor-e5-2660-v3-25m-cache-2-60-ghz.html
 Xeon E5-2665,115,8,14.4,,,,https://ark.intel.com/content/www/us/en/ark/products/64597/intel-xeon-processor-e5-2665-20m-cache-2-40-ghz-8-00-gt-s-intel-qpi.html
+Xeon E5-2650 v2,95,8,11.9,,,,https://www.techpowerup.com/cpu-specs/xeon-e5-2650-v2.c1661
 Xeon E5-2670,115,8,14.4,,,,https://ark.intel.com/content/www/us/en/ark/products/64595/intel-xeon-processor-e5-2670-20m-cache-2-60-ghz-8-00-gt-s-intel-qpi.html
 Xeon E5-2670 v2,115,10,11.5,,,,https://ark.intel.com/content/www/us/en/ark/products/75275/intel-xeon-processor-e5-2670-v2-25m-cache-2-50-ghz.html
 Xeon E5-2680 v3,120,12,10.0,,,,https://www.intel.co.uk/content/www/uk/en/products/processors/xeon/e5-processors/e5-2680-v3.html
 Xeon E5-2683 v4,120,16,7.5,,,,https://www.intel.co.uk/content/www/uk/en/products/processors/xeon/e5-processors/e5-2683-v4.html
 Xeon E5-2690 v2,130,10,13.0,,,,https://ark.intel.com/content/www/us/en/ark/products/75279/intel-xeon-processor-e5-2690-v2-25m-cache-3-00-ghz.html
 Xeon E5-2690 v3,135,12,11.3,,,,https://ark.intel.com/content/www/us/en/ark/products/81713/intel-xeon-processor-e5-2690-v3-30m-cache-2-60-ghz.html
+Xeon E5-2695 v3,120,14,8.6,,,,https://www.techpowerup.com/cpu-specs/xeon-e5-2695-v3.c2894
 Xeon E5-2695 v4,120,18,6.7,,,,https://ark.intel.com/content/www/us/en/ark/products/91316/intel-xeon-processor-e5-2695-v4-45m-cache-2-10-ghz.html
 Xeon E5-2697 v4,145,18,8.1,,,,https://ark.intel.com/content/www/us/en/ark/products/91755/intel-xeon-processor-e5-2697-v4-45m-cache-2-30-ghz.html
 Xeon E5-2699 v3,145,18,8.1,,,,https://ark.intel.com/content/www/us/en/ark/products/81061/intel-xeon-processor-e5-2699-v3-45m-cache-2-30-ghz.html
@@ -77,6 +80,7 @@ Xeon E5-2699 v4,145,22,6.6,,,,https://ark.intel.com/content/www/us/en/ark/produc
 Xeon E5-4610 v4,105,10,10.5,,,,https://ark.intel.com/content/www/us/en/ark/products/93812/intel-xeon-processor-e5-4610-v4-25m-cache-1-80-ghz.html
 Xeon E5-4620,95,8,11.9,,,,https://ark.intel.com/content/www/us/en/ark/products/64607/intel-xeon-processor-e5-4620-16m-cache-2-20-ghz-7-20-gt-s-intel-qpi.html
 Xeon E5-4650L,115,8,14.4,,,,https://ark.intel.com/content/www/us/en/ark/products/64606/intel-xeon-processor-e5-4650l-20m-cache-2-60-ghz-8-00-gt-s-intel-qpi.html
+Xeon E7-4850 v2 ,105,12,8.8,,,,https://ark.intel.com/content/www/us/en/ark/products/75248/intel-xeon-processor-e7-4850-v2-24m-cache-2-30-ghz.html
 Xeon E7-8867 v3,165,16,10.3,,,,https://ark.intel.com/content/www/us/en/ark/products/84681/intel-xeon-processor-e7-8867-v3-45m-cache-2-50-ghz.html
 Xeon E7-8880 v4,150,22,6.8,,,,https://www.intel.co.uk/content/www/uk/en/products/processors/xeon/e7-processors/e7-8880-v4.html
 Xeon Gold 6142,150,16,9.4,,,,https://ark.intel.com/content/www/us/en/ark/products/120487/intel-xeon-gold-6142-processor-22m-cache-2-60-ghz.html

--- a/data/latest/TDP_gpu.csv
+++ b/data/latest/TDP_gpu.csv
@@ -19,3 +19,5 @@ TPU v3 pod,288000,,288000,https://www.nextplatform.com/2018/05/10/tearing-apart-
 NVIDIA A100 PCIe,250,,250,https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/a100/pdf/a100-80gb-datasheet-update-nvidia-us-1521051-r2-web.pdf
 NVIDIA Tesla P4,75,,75,https://www.techpowerup.com/gpu-specs/tesla-p4.c2879
 NVIDIA Tesla K80,300,,300,https://www.techpowerup.com/gpu-specs/tesla-k80.c2616
+NVIDIA Tesla V100S,250,,250,https://technical.city/en/video/Tesla-V100S-PCIe-32-GB
+NVIDIA Tesla P100,250,,250,https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/tesla-p100/pdf/nvidia-tesla-p100-PCIe-datasheet.pdf


### PR DESCRIPTION
Adds CPUs and GPUs used by University of Arizona's HPC (https://hpcdocs.hpc.arizona.edu/resources/compute_resources/)

I hope I added these in the right spot—it isn't clear if one should add to `latest/` or `dev/`