### PR TITLE
fix carbon intensity geo map

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,6 +33,7 @@ current_version = 'v2.2'
 
 data_dir = os.path.join(os.path.abspath(''),'data')
 image_dir = os.path.join('assets/images')
+assets_dir = os.path.join('assets')
 static_image_route = '/static/'
 
 # We download each csv and store it in a pd.DataFrame
@@ -338,8 +339,9 @@ layout_map['geo'] = dict(
 
 mapCI = go.Figure(
     data=go.Choropleth(
-        geojson=os.path.join(data_dir, 'world.geo.json'),
+        geojson=os.path.join(assets_dir, 'world.geo.json'),
         locations = map_df.ISO3,
+        featureidkey="properties.ISO_A3",
         locationmode='geojson-id',
         z=map_df.carbonIntensity.astype(float),
         colorscale=myColors['map1'],


### PR DESCRIPTION
## Noticed Behaviour
Currently the "Carbon Intensity across the world" panel is not fully rendering. Screenshot below for reference:

![carbon_intensity_map_current](https://github.com/user-attachments/assets/6a5a3a08-42fa-405f-93fa-2ed8c3e0f60a)

Relevant error message can be seen in the browser console logs:

![console_error_server](https://github.com/user-attachments/assets/a5b22900-4233-44d8-89e5-c99ff4218cbe)

## Local Reproduction
Can see the same behaviour while running the app locally

![console_error_local](https://github.com/user-attachments/assets/34ac052f-47ac-473f-89fd-4b3224419bc5)

## Issue/Proposed fix
- In the local reproduction, we can see its trying to access the absolute os.path - which isn't a valid/available URI for web server. 
**Fix:** moving the world.geo.json form data folder to assets folder (with the assumption that it semantically contains resources accessible over the web) and passing the geo json from assets path.
- After above change, the world map loads but is just plain. It doesn't show any carbonIntensity data or colour coded
**Fix:** need to map the locations to "properties.ISO_A3" on world.geo.json using "featureidkey"

## Behaviour after fix
![carbon_intensity_map_fixed](https://github.com/user-attachments/assets/815d2e20-61e0-4193-8657-cfcef6635fab)

Would be glad if you can review this PR and let me know of any comments. Happy to address any suggestions and make further commits.

Thanks
Revant