### PR TITLE
Car carbon equivalent estimation explained

### DIFF
--- a/blueprints/metrics/metrics_blueprint.py
+++ b/blueprints/metrics/metrics_blueprint.py
@@ -184,17 +184,27 @@ class MetricsBlueprint(DashBlueprint):
                             'padding': '13px'
                         },
                     ),
-
                     html.Div(
                         [
-                            loading_wrapper(html.Div(
-                                id="driving_text",
-                            )),
-
-                            html.P(translatable_div_text("in_a_passenger_car").embed(self))
+                            loading_wrapper(html.Div(id="driving_text")),
+                            html.P(
+                                [
+                                    translatable_div_text("in_a_passenger_car").embed(self),
+                                    html.Span(
+                                        [
+                                            html.Span('i', className='tooltip-icon'),
+                                            html.Span(
+                                                translatable_div_text("in_a_passenger_car_tooltip").embed(self),
+                                                className='tooltip-text'
+                                            ),
+                                        ],
+                                        className='tooltip',
+                                    ),
+                                ]
+                            ),
                         ],
                         className='caption-icons'
-                    )
+                    ),
                 ],
                 className="container mini-box"
             ),

--- a/blueprints/translation/translation_dicts.py
+++ b/blueprints/translation/translation_dicts.py
@@ -497,8 +497,8 @@ TRANSLATIONS_DICT = {
         "fr": "in a passenger car",
     },
     "in_a_passenger_car_tooltip": {
-        "en": "Equivalent distance driven by a petrol/diesel car emitting the same amount of CO₂",
-        "fr": "Equivalent distance driven by a petrol/diesel car emitting the same amount of CO₂",
+"en": "Equivalent distance driven by a petrol/diesel car emitting the same amount of GHGs",
+"fr": "",
     },
     "flights": {
         "en": "flights",

--- a/blueprints/translation/translation_dicts.py
+++ b/blueprints/translation/translation_dicts.py
@@ -496,6 +496,10 @@ TRANSLATIONS_DICT = {
         "en": "in a passenger car",
         "fr": "in a passenger car",
     },
+    "in_a_passenger_car_tooltip": {
+        "en": "Equivalent distance driven by a petrol/diesel car emitting the same amount of CO₂",
+        "fr": "Equivalent distance driven by a petrol/diesel car emitting the same amount of CO₂",
+    },
     "flights": {
         "en": "flights",
         "fr": "vols",


### PR DESCRIPTION
Issue #93 

- Added a tooltip icon and text next to the existing label in the car estimations box. 
- Used the same css as other tooltips (the ones in the form)

<img width="377" height="306" alt="Screenshot 2026-05-13 at 14 12 19" src="https://github.com/user-attachments/assets/b361ef26-5f38-4047-918e-7900607af9cc" />
<img width="393" height="353" alt="Screenshot 2026-05-13 at 14 12 13" src="https://github.com/user-attachments/assets/9213dcc0-3d74-4d8e-acef-44c0b895402a" />
